### PR TITLE
Fixes and Quality of Life updates for run task scaffolding

### DIFF
--- a/internal/runtask/run_task_handler.go
+++ b/internal/runtask/run_task_handler.go
@@ -105,13 +105,6 @@ func handleTFCRequestWrapper(task *ScaffoldingRunTask, original func(http.Respon
 			return
 		}
 
-		// Send response to TFC and exit early
-		if callbackResp != nil {
-			task.logger.Println("Error occurred while parsing the request")
-			original(w, r, runTaskReq, task, callbackResp)
-			return
-		}
-
 		// Get TFC Plan if the task is running in the post-plan or pre-apply stages
 		if runTaskReq.Stage == api.PostPlan || runTaskReq.Stage == api.PreApply {
 			plan, err := retrieveTFCPlan(runTaskReq)

--- a/internal/runtask/run_task_scaffolding.go
+++ b/internal/runtask/run_task_scaffolding.go
@@ -4,6 +4,7 @@
 package runtask
 
 import (
+	"fmt"
 	"log"
 	"os"
 
@@ -14,15 +15,6 @@ import (
 	"github.com/hashicorp/terraform-run-task-scaffolding-go/internal/sdk/handler"
 )
 
-const (
-	// DefaultBind is the port the run task HTTP server will run on.
-	DefaultBind = ":22180"
-	// DefaultPath is the URL path for the run task to receive HTTP request from TFC or TFE.
-	DefaultPath = "/runtask"
-	// HMACKey is the customizable secret which TFC or TFE will use to sign requests to the run task.
-	HMACKey = "secret123"
-)
-
 // ScaffoldingRunTask defines the run task implementation.
 type ScaffoldingRunTask struct {
 	config handler.Configuration
@@ -31,11 +23,11 @@ type ScaffoldingRunTask struct {
 
 // Configure defines the configuration for the server and run task.
 // This method is called before the server is initialized.
-func (r *ScaffoldingRunTask) Configure() {
+func (r *ScaffoldingRunTask) Configure(addr string, path string, hmacKey string) {
 	r.config = handler.Configuration{
-		Addr:    DefaultBind,
-		Path:    DefaultPath,
-		HmacKey: HMACKey,
+		Addr:    fmt.Sprintf(":%s", addr),
+		Path:    path,
+		HmacKey: hmacKey,
 	}
 }
 
@@ -44,10 +36,6 @@ func (r *ScaffoldingRunTask) Configure() {
 func (r *ScaffoldingRunTask) VerifyRequest(request api.Request) (*handler.CallbackBuilder, error) {
 
 	// Run custom verification logic
-	//if request.OrganizationName != "TFC-ORG" {
-	//	return handler.NewCallbackBuilder(api.TaskFailed).WithMessage("Unexpected Org Name")
-	//}
-
 	r.logger.Println("Successfully verified request")
 	return handler.NewCallbackBuilder(api.TaskPassed).WithMessage("Custom Passed Message"), nil
 }
@@ -56,7 +44,8 @@ func (r *ScaffoldingRunTask) VerifyRequest(request api.Request) (*handler.Callba
 // This method is only called if the run task is running in the post-plan or pre-apply stages
 // and if VerifyRequest returns a nil response with no error.
 func (r *ScaffoldingRunTask) VerifyPlan(request api.Request, plan tfjson.Plan) (*handler.CallbackBuilder, error) {
-	return nil, nil
+	r.logger.Println("Successfully verified plan")
+	return handler.NewCallbackBuilder(api.TaskPassed).WithMessage("Custom Passed Message"), nil
 }
 
 // NewRunTask instantiates a new ScaffoldingRunTask with a new Logger.

--- a/internal/sdk/api/structs.go
+++ b/internal/sdk/api/structs.go
@@ -23,7 +23,7 @@ const (
 	PrePlan   string = "pre_plan"
 	PostPlan  string = "post_plan"
 	PreApply  string = "pre_apply"
-	PostApply string = "pre_apply"
+	PostApply string = "post_apply"
 )
 
 type Request struct {

--- a/internal/sdk/api/structs.go
+++ b/internal/sdk/api/structs.go
@@ -20,9 +20,10 @@ const (
 )
 
 const (
-	PrePlan  string = "pre_plan"
-	PostPlan string = "post_plan"
-	PreApply string = "pre-apply"
+	PrePlan   string = "pre_plan"
+	PostPlan  string = "post_plan"
+	PreApply  string = "pre_apply"
+	PostApply string = "pre_apply"
 )
 
 type Request struct {

--- a/main.go
+++ b/main.go
@@ -4,11 +4,19 @@
 package main
 
 import (
+	"flag"
+
 	"github.com/hashicorp/terraform-run-task-scaffolding-go/internal/runtask"
 )
 
 func main() {
+	// Define command-line parameters
+	var addr = flag.String("addr", "22180", "the port the run task HTTP server will run on")
+	var path = flag.String("path", "/runtask", "the URL path for the run task to receive HTTP request from TFC or TFE")
+	var hmacKey = flag.String("hmacKey", "", "the customizable secret which TFC or TFE will use to sign requests to the run task")
+	flag.Parse()
+
 	task := runtask.NewRunTask()
-	task.Configure()
+	task.Configure(*addr, *path, *hmacKey)
 	runtask.HandleRequests(task)
 }


### PR DESCRIPTION
Whilst working through importing and using the `terraform-run-task-scaffolding-go` in my own project, I came across a couple of issues with the repository as supplied.

### Issues
1. `struct.go` references tf run phases that weren't correct
2. The handler would always exit early in a happy path, without assessing the phase of the run. This I assume, was to guard against the fact that VerifyPlan always returns nil, which causes an error condition from which the run task can't recover.
3. Not an error, but slightly annoying - addr, path, and hmac were all hardcoded. 

### Fixes
1. Corrected run phases in struct.go
2. Updated VerifyPlan to return correctly in a happy path condition and demonstrate the function running to completion
3. Updated `main.go` to allow addr, path, and hmackey to be passed as CLI arguments.